### PR TITLE
Fix styles selector for preview-head.html styles

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <style type="text/css">
   /* This is a part of the reset.css written by Eric Meyer */
-  strong {
+  #root > div > strong {
     margin: 0;
     padding: 0;
     border: 0;


### PR DESCRIPTION
It should apply `preview-head.html` styles only to the story and not the documentation wrapper text, since the `root` id only applies to the story.